### PR TITLE
Ref: Improved Project Structure through simple refactorings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ node_modules/
 /coverage-playwright
 /monocart-report
 /.v8-coverage
-/playwright-test-artifacts
+tests/playwright-test-artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,6 @@ next-env.d.ts
 node_modules/
 
 
-/playwright-report/
-/blob-report/
-/playwright/.cache/
-/coverage-playwright
-/monocart-report
+/playwright-coverage
 /.v8-coverage
 tests/playwright-test-artifacts

--- a/global-teardown.js
+++ b/global-teardown.js
@@ -56,6 +56,10 @@ const globalTeardown = async (config) => {
     }
     await addCoverageReport(coverageList, mockTestInfo)
   }
+
+  //* remove .v8-coverage directory
+  console.log('globalTeardown: Removing .v8-coverage directory')
+  fs.rm('.v8-coverage', { recursive: true }, (err) => {})
 }
 
 export default globalTeardown

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
   // If a test fails, retry it additional 2 times
   retries: 2,
   // Artifacts folder where screenshots, videos, and traces are stored.
-  outputDir: 'playwright-test-artifacts/',
+  outputDir: 'tests/playwright-test-artifacts/',
 
   // Run your local dev server before starting the tests:
   // https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,9 +2,12 @@ import { defineConfig, devices } from '@playwright/test'
 
 import { CoverageReportOptions } from 'monocart-reporter'
 
+const outputDir = 'playwright-coverage'
+
 const coverageReportOptions: CoverageReportOptions = {
   // logging: 'debug',
   name: 'Next.js Coverage Report',
+  outputDir: `${outputDir}/coverage`,
 
   entryFilter: (entry) => {
     // both client side and server side
@@ -64,6 +67,7 @@ export default defineConfig({
       'monocart-reporter',
       {
         coverage: coverageReportOptions,
+        outputFile: `${outputDir}/index.html`,
       },
     ],
   ],


### PR DESCRIPTION
This pull request includes updates to the test configuration and cleanup processes. The most important changes involve adding a new output directory for coverage reports and modifying the output directory for test artifacts.

Configuration updates:

* [`playwright.config.ts`](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92R5-R10): Initialized the `outputDir` property to move the coverage-report output directory from `monocart-report` to `playwright-coverage`
* [`playwright.config.ts`](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92L46-R49): Changed the `outputDir` for test artifacts from `'playwright-test-artifacts/'` to `'tests/playwright-test-artifacts/'`.

Cleanup process:

* [`global-teardown.js`](diffhunk://#diff-98f9fbd9bb9c265fa6d45ee9b0db7f988ec02927dec95cb67b8aec5b2811dae6R59-R62): Added a step to remove the `.v8-coverage` directory during the global teardown process, to reduce cluttering of the project structure.